### PR TITLE
feat(auth): login, forgot-password and reset-password UI

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,7 +8,7 @@ export const routes: Routes = [
   },
   {
     path: '',
-    redirectTo: '/auth/register',
+    redirectTo: '/auth/login',
     pathMatch: 'full',
   },
 ];

--- a/src/app/features/auth/auth.routes.ts
+++ b/src/app/features/auth/auth.routes.ts
@@ -2,6 +2,13 @@ import { Routes } from '@angular/router';
 
 export const authRoutes: Routes = [
   {
+    path: 'login',
+    loadComponent: () =>
+      import('./pages/login-page/login-page.component').then(
+        (c) => c.LoginPageComponent,
+      ),
+  },
+  {
     path: 'register',
     loadComponent: () =>
       import('./pages/register-page/register-page.component').then(
@@ -16,8 +23,22 @@ export const authRoutes: Routes = [
       ),
   },
   {
+    path: 'forgot-password',
+    loadComponent: () =>
+      import('./pages/forgot-password-page/forgot-password-page.component').then(
+        (c) => c.ForgotPasswordPageComponent,
+      ),
+  },
+  {
+    path: 'reset-password',
+    loadComponent: () =>
+      import('./pages/reset-password-page/reset-password-page.component').then(
+        (c) => c.ResetPasswordPageComponent,
+      ),
+  },
+  {
     path: '',
-    redirectTo: 'register',
+    redirectTo: 'login',
     pathMatch: 'full',
   },
 ];

--- a/src/app/features/auth/models/forgot-password.model.ts
+++ b/src/app/features/auth/models/forgot-password.model.ts
@@ -1,0 +1,13 @@
+export interface ForgotPasswordRequest {
+  email: string;
+}
+
+export interface ForgotPasswordResponse {
+  success: boolean;
+  data: {
+    message: string;
+    resetToken?: string;
+    expiresIn?: string;
+  };
+  timestamp: string;
+}

--- a/src/app/features/auth/models/login.model.ts
+++ b/src/app/features/auth/models/login.model.ts
@@ -1,0 +1,19 @@
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  success: boolean;
+  data: {
+    accessToken: string;
+    refreshToken: string;
+    expiresIn: string;
+    user: {
+      id: string;
+      email: string;
+      nombre: string;
+    };
+  };
+  timestamp: string;
+}

--- a/src/app/features/auth/models/reset-password.model.ts
+++ b/src/app/features/auth/models/reset-password.model.ts
@@ -1,0 +1,12 @@
+export interface ResetPasswordRequest {
+  token: string;
+  password: string;
+}
+
+export interface ResetPasswordResponse {
+  success: boolean;
+  data: {
+    message: string;
+  };
+  timestamp: string;
+}

--- a/src/app/features/auth/pages/forgot-password-page/forgot-password-page.component.ts
+++ b/src/app/features/auth/pages/forgot-password-page/forgot-password-page.component.ts
@@ -1,0 +1,201 @@
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-forgot-password-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+  ],
+  template: `
+    <div class="forgot-container">
+      <mat-card class="forgot-card">
+        <mat-card-header>
+          <mat-card-title>Recuperar Contraseña</mat-card-title>
+          <mat-card-subtitle>Te enviaremos un token de recuperación</mat-card-subtitle>
+        </mat-card-header>
+
+        <mat-card-content>
+          @if (emailSent()) {
+            <div class="success-message">
+              <mat-icon color="primary">mail</mat-icon>
+              <h3>Correo enviado</h3>
+              <p>{{ successMessage() }}</p>
+              @if (resetToken(); as token) {
+                <p class="token-info">Token: <code>{{ token }}</code></p>
+              }
+              <button mat-flat-button color="primary" class="full-width" routerLink="/auth/reset-password">
+                Ir a restablecer contraseña
+              </button>
+            </div>
+          } @else {
+            <form [formGroup]="forgotForm" (ngSubmit)="onSubmit()" class="forgot-form">
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>Correo electrónico</mat-label>
+                <input matInput formControlName="email" type="email" placeholder="correo@ejemplo.com" />
+                @if (forgotForm.get('email')?.hasError('required') && forgotForm.get('email')?.touched) {
+                  <mat-error>El correo es requerido</mat-error>
+                }
+                @if (forgotForm.get('email')?.hasError('email') && forgotForm.get('email')?.touched) {
+                  <mat-error>Ingresa un correo válido</mat-error>
+                }
+              </mat-form-field>
+
+              @if (error(); as err) {
+                <div class="error-message">
+                  <mat-icon color="warn">error</mat-icon>
+                  <span>{{ err }}</span>
+                </div>
+              }
+
+              <button mat-flat-button color="primary" class="full-width submit-btn" type="submit" [disabled]="forgotForm.invalid || loading()">
+                @if (loading()) {
+                  <mat-spinner diameter="20"></mat-spinner>
+                } @else {
+                  Enviar token de recuperación
+                }
+              </button>
+            </form>
+
+            <div class="back-link">
+              <a routerLink="/auth/login">Volver a inicio de sesión</a>
+            </div>
+          }
+        </mat-card-content>
+      </mat-card>
+    </div>
+  `,
+  styles: `
+    .forgot-container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      padding: 16px;
+      background: #f5f5f5;
+    }
+
+    .forgot-card {
+      max-width: 420px;
+      width: 100%;
+      padding: 16px;
+    }
+
+    .forgot-card mat-card-header {
+      margin-bottom: 16px;
+    }
+
+    .forgot-form {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .full-width {
+      width: 100%;
+    }
+
+    .submit-btn {
+      margin-top: 8px;
+      height: 48px;
+    }
+
+    .submit-btn mat-spinner {
+      display: inline-block;
+    }
+
+    .error-message {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: #fce4ec;
+      border-radius: 4px;
+      color: #c62828;
+      font-size: 14px;
+    }
+
+    .success-message {
+      text-align: center;
+      padding: 24px 16px;
+    }
+
+    .success-message mat-icon {
+      font-size: 48px;
+      width: 48px;
+      height: 48px;
+    }
+
+    .token-info {
+      background: #f5f5f5;
+      padding: 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      word-break: break-all;
+    }
+
+    .back-link {
+      text-align: center;
+      margin-top: 16px;
+      font-size: 14px;
+    }
+  `,
+})
+export class ForgotPasswordPageComponent {
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly emailSent = signal(false);
+  readonly resetToken = signal<string | null>(null);
+  readonly successMessage = signal('');
+
+  readonly forgotForm: FormGroup;
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly authService: AuthService,
+  ) {
+    this.forgotForm = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+    });
+  }
+
+  onSubmit(): void {
+    if (this.forgotForm.invalid) return;
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.authService.forgotPassword(this.forgotForm.value).subscribe({
+      next: (res) => {
+        this.emailSent.set(true);
+        this.successMessage.set(res.data.message);
+        if (res.data.resetToken) {
+          this.resetToken.set(res.data.resetToken);
+        }
+        this.loading.set(false);
+      },
+      error: () => {
+        this.emailSent.set(true);
+        this.successMessage.set('Si el correo está registrado, recibirá un enlace de recuperación.');
+        this.loading.set(false);
+      },
+    });
+  }
+}

--- a/src/app/features/auth/pages/login-page/login-page.component.ts
+++ b/src/app/features/auth/pages/login-page/login-page.component.ts
@@ -1,0 +1,194 @@
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-login-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+  ],
+  template: `
+    <div class="login-container">
+      <mat-card class="login-card">
+        <mat-card-header>
+          <mat-card-title>Iniciar Sesión</mat-card-title>
+          <mat-card-subtitle>Accede a neoMotors</mat-card-subtitle>
+        </mat-card-header>
+
+        <mat-card-content>
+          <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" class="login-form">
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>Correo electrónico</mat-label>
+              <input matInput formControlName="email" type="email" placeholder="correo@ejemplo.com" />
+              @if (loginForm.get('email')?.hasError('required') && loginForm.get('email')?.touched) {
+                <mat-error>El correo es requerido</mat-error>
+              }
+              @if (loginForm.get('email')?.hasError('email') && loginForm.get('email')?.touched) {
+                <mat-error>Ingresa un correo válido</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>Contraseña</mat-label>
+              <input matInput formControlName="password" [type]="hidePassword() ? 'password' : 'text'" />
+              <button mat-icon-button matSuffix (click)="hidePassword.set(!hidePassword())" type="button">
+                <mat-icon>{{ hidePassword() ? 'visibility_off' : 'visibility' }}</mat-icon>
+              </button>
+              @if (loginForm.get('password')?.hasError('required') && loginForm.get('password')?.touched) {
+                <mat-error>La contraseña es requerida</mat-error>
+              }
+            </mat-form-field>
+
+            @if (error(); as err) {
+              <div class="error-message">
+                <mat-icon color="warn">error</mat-icon>
+                <span>{{ err }}</span>
+              </div>
+            }
+
+            <button mat-flat-button color="primary" class="full-width submit-btn" type="submit" [disabled]="loginForm.invalid || loading()">
+              @if (loading()) {
+                <mat-spinner diameter="20"></mat-spinner>
+              } @else {
+                Iniciar sesión
+              }
+            </button>
+          </form>
+
+          <div class="links">
+            <a routerLink="/auth/forgot-password" class="forgot-link">¿Olvidaste tu contraseña?</a>
+          </div>
+
+          <div class="register-link">
+            <span>¿No tienes cuenta?</span>
+            <a routerLink="/auth/register">Regístrate</a>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  `,
+  styles: `
+    .login-container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      padding: 16px;
+      background: #f5f5f5;
+    }
+
+    .login-card {
+      max-width: 420px;
+      width: 100%;
+      padding: 16px;
+    }
+
+    .login-card mat-card-header {
+      margin-bottom: 16px;
+    }
+
+    .login-form {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .full-width {
+      width: 100%;
+    }
+
+    .submit-btn {
+      margin-top: 8px;
+      height: 48px;
+    }
+
+    .submit-btn mat-spinner {
+      display: inline-block;
+    }
+
+    .error-message {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: #fce4ec;
+      border-radius: 4px;
+      color: #c62828;
+      font-size: 14px;
+    }
+
+    .links {
+      text-align: center;
+      margin-top: 16px;
+    }
+
+    .forgot-link {
+      font-size: 14px;
+    }
+
+    .register-link {
+      text-align: center;
+      margin-top: 8px;
+      font-size: 14px;
+    }
+
+    .register-link a {
+      margin-left: 4px;
+    }
+  `,
+})
+export class LoginPageComponent {
+  readonly hidePassword = signal(true);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+
+  readonly loginForm: FormGroup;
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly authService: AuthService,
+    private readonly router: Router,
+  ) {
+    this.loginForm = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', Validators.required],
+    });
+  }
+
+  onSubmit(): void {
+    if (this.loginForm.invalid) return;
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.authService.login(this.loginForm.value).subscribe({
+      next: (res) => {
+        localStorage.setItem('accessToken', res.data.accessToken);
+        localStorage.setItem('refreshToken', res.data.refreshToken);
+        this.loading.set(false);
+        this.router.navigate(['/']);
+      },
+      error: (err) => {
+        this.error.set(err.error?.message || 'Error al iniciar sesión');
+        this.loading.set(false);
+      },
+    });
+  }
+}

--- a/src/app/features/auth/pages/reset-password-page/reset-password-page.component.ts
+++ b/src/app/features/auth/pages/reset-password-page/reset-password-page.component.ts
@@ -1,0 +1,217 @@
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-reset-password-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+  ],
+  template: `
+    <div class="reset-container">
+      <mat-card class="reset-card">
+        <mat-card-header>
+          <mat-card-title>Restablecer Contraseña</mat-card-title>
+          <mat-card-subtitle>Ingresa el token y tu nueva contraseña</mat-card-subtitle>
+        </mat-card-header>
+
+        <mat-card-content>
+          @if (resetDone()) {
+            <div class="success-message">
+              <mat-icon color="primary">check_circle</mat-icon>
+              <h3>¡Contraseña restablecida!</h3>
+              <p>Tu contraseña ha sido cambiada exitosamente.</p>
+              <button mat-flat-button color="primary" routerLink="/auth/login">
+                Iniciar sesión
+              </button>
+            </div>
+          } @else {
+            <form [formGroup]="resetForm" (ngSubmit)="onSubmit()" class="reset-form">
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>Token de recuperación</mat-label>
+                <input matInput formControlName="token" placeholder="00000000-0000-0000-0000-000000000000" />
+                @if (resetForm.get('token')?.hasError('required') && resetForm.get('token')?.touched) {
+                  <mat-error>El token es requerido</mat-error>
+                }
+              </mat-form-field>
+
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>Nueva contraseña</mat-label>
+                <input matInput formControlName="password" [type]="hidePassword() ? 'password' : 'text'" />
+                <button mat-icon-button matSuffix (click)="hidePassword.set(!hidePassword())" type="button">
+                  <mat-icon>{{ hidePassword() ? 'visibility_off' : 'visibility' }}</mat-icon>
+                </button>
+                @if (resetForm.get('password')?.hasError('required') && resetForm.get('password')?.touched) {
+                  <mat-error>La contraseña es requerida</mat-error>
+                }
+                @if (resetForm.get('password')?.hasError('minlength') && resetForm.get('password')?.touched) {
+                  <mat-error>Mínimo 8 caracteres</mat-error>
+                }
+              </mat-form-field>
+
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>Confirmar contraseña</mat-label>
+                <input matInput formControlName="confirmPassword" [type]="hidePassword() ? 'password' : 'text'" />
+                @if (resetForm.hasError('mismatch') && resetForm.get('confirmPassword')?.touched) {
+                  <mat-error>Las contraseñas no coinciden</mat-error>
+                }
+              </mat-form-field>
+
+              @if (error(); as err) {
+                <div class="error-message">
+                  <mat-icon color="warn">error</mat-icon>
+                  <span>{{ err }}</span>
+                </div>
+              }
+
+              <button mat-flat-button color="primary" class="full-width submit-btn" type="submit" [disabled]="resetForm.invalid || loading()">
+                @if (loading()) {
+                  <mat-spinner diameter="20"></mat-spinner>
+                } @else {
+                  Restablecer contraseña
+                }
+              </button>
+            </form>
+
+            <div class="links">
+              <a routerLink="/auth/forgot-password">Solicitar nuevo token</a>
+              <a routerLink="/auth/login">Volver a inicio de sesión</a>
+            </div>
+          }
+        </mat-card-content>
+      </mat-card>
+    </div>
+  `,
+  styles: `
+    .reset-container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      padding: 16px;
+      background: #f5f5f5;
+    }
+
+    .reset-card {
+      max-width: 420px;
+      width: 100%;
+      padding: 16px;
+    }
+
+    .reset-card mat-card-header {
+      margin-bottom: 16px;
+    }
+
+    .reset-form {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .full-width {
+      width: 100%;
+    }
+
+    .submit-btn {
+      margin-top: 8px;
+      height: 48px;
+    }
+
+    .submit-btn mat-spinner {
+      display: inline-block;
+    }
+
+    .error-message {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: #fce4ec;
+      border-radius: 4px;
+      color: #c62828;
+      font-size: 14px;
+    }
+
+    .success-message {
+      text-align: center;
+      padding: 24px 16px;
+    }
+
+    .success-message mat-icon {
+      font-size: 48px;
+      width: 48px;
+      height: 48px;
+    }
+
+    .links {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+      margin-top: 16px;
+      font-size: 14px;
+    }
+  `,
+})
+export class ResetPasswordPageComponent {
+  readonly hidePassword = signal(true);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly resetDone = signal(false);
+
+  readonly resetForm: FormGroup;
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly authService: AuthService,
+  ) {
+    this.resetForm = this.fb.group({
+      token: ['', Validators.required],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      confirmPassword: ['', Validators.required],
+    }, { validators: this.passwordMatchValidator });
+  }
+
+  private passwordMatchValidator(group: FormGroup) {
+    const password = group.get('password')?.value;
+    const confirm = group.get('confirmPassword')?.value;
+    return password === confirm ? null : { mismatch: true };
+  }
+
+  onSubmit(): void {
+    if (this.resetForm.invalid) return;
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    const { confirmPassword, ...dto } = this.resetForm.value;
+
+    this.authService.resetPassword(dto).subscribe({
+      next: () => {
+        this.resetDone.set(true);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.error.set(err.error?.message || 'Error al restablecer la contraseña');
+        this.loading.set(false);
+      },
+    });
+  }
+}

--- a/src/app/features/auth/services/auth.service.ts
+++ b/src/app/features/auth/services/auth.service.ts
@@ -1,9 +1,12 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 import { RegisterRequest, RegisterResponse } from '../models/register.model';
 import { VerifyRequest, VerifyResponse } from '../models/verify.model';
+import { LoginRequest, LoginResponse } from '../models/login.model';
+import { ForgotPasswordRequest, ForgotPasswordResponse } from '../models/forgot-password.model';
+import { ResetPasswordRequest, ResetPasswordResponse } from '../models/reset-password.model';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -17,5 +20,17 @@ export class AuthService {
 
   verify(dto: VerifyRequest): Observable<VerifyResponse> {
     return this.http.post<VerifyResponse>(`${this.apiUrl}/verify`, dto);
+  }
+
+  login(dto: LoginRequest): Observable<LoginResponse> {
+    return this.http.post<LoginResponse>(`${this.apiUrl}/login`, dto);
+  }
+
+  forgotPassword(dto: ForgotPasswordRequest): Observable<ForgotPasswordResponse> {
+    return this.http.post<ForgotPasswordResponse>(`${this.apiUrl}/forgot-password`, dto);
+  }
+
+  resetPassword(dto: ResetPasswordRequest): Observable<ResetPasswordResponse> {
+    return this.http.post<ResetPasswordResponse>(`${this.apiUrl}/reset-password`, dto);
   }
 }


### PR DESCRIPTION
## Descripción

Interfaz de usuario para inicio de sesión, recuperación y restablecimiento de contraseña.

## Rutas implementadas

- /auth/login - Inicio de sesión con almacenamiento de JWT
- /auth/forgot-password - Solicitar token de recuperación
- /auth/reset-password - Restablecer contraseña con token

## Criterios de Aceptación

- [x] Formulario de login con validación reactiva
- [x] Almacenamiento de accessToken y refreshToken en localStorage
- [x] Formulario de solicitud de recuperación de contraseña
- [x] Formulario de restablecimiento con confirmación de contraseña
- [x] Validación de coincidencia de contraseñas
- [x] Manejo de errores HTTP con mensajes al usuario
- [x] Lazy loading para todas las rutas
- [x] Navegación entre todas las páginas de autenticación