### PR TITLE
fix(register): flatten register-page response access

### DIFF
--- a/src/app/features/auth/pages/register-page/register-page.component.ts
+++ b/src/app/features/auth/pages/register-page/register-page.component.ts
@@ -214,8 +214,8 @@ export class RegisterPageComponent {
 
     this.authService.register(this.registerForm.value).subscribe({
       next: (res) => {
-        this.verificationToken.set(res.data.verificationToken);
-        this.expiresIn.set(res.data.expiresIn);
+        this.verificationToken.set(res.verificationToken);
+        this.expiresIn.set(res.expiresIn);
         this.loading.set(false);
       },
       error: (err) => {


### PR DESCRIPTION
Corrige register-page.component.ts para acceder a res.verificationToken y res.expiresIn en vez de res.data.*, acorde al modelo RegisterResponse aplanado.