### PR TITLE
fix(overlay): add mat.core() to fix mat-select dropdown positioning

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,6 +8,8 @@ $theme: mat.define-theme((
   ),
 ));
 
+@include mat.core();
+
 html {
   @include mat.all-component-themes($theme);
 }


### PR DESCRIPTION
## Problema

Los componentes `mat-select` de **Régimen fiscal** y **Tema** mostraban el dropdown en la esquina inferior izquierda de la pantalla en lugar de debajo del campo correspondiente.

## Causa raíz

En `styles.scss` faltaba `@include mat.core();`. Este mixin llama internamente a `cdk.overlay()`, que genera las reglas CSS esenciales para el CDK Overlay:

- `.cdk-overlay-container { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 1000; }`
- `.cdk-overlay-pane { position: absolute; ... }`
- `.cdk-global-overlay-wrapper { display: flex; position: absolute; ... }`
- `.cdk-overlay-connected-position-bounding-box { ... }"

Sin estas reglas, el contenedor del overlay tenía `position: static` por defecto, y los paneles aparecían en la esquina inferior izquierda del viewport.

## Corrección

Agregar `@include mat.core();` en `styles.scss` antes de `mat.all-component-themes()`.

## Archivos modificados

- `src/styles.scss` — añadida línea 11: `@include mat.core();`

## Verificación

- Build de producción exitoso
- Los estilos `.cdk-overlay-*` ahora aparecen en el CSS compilado
- No afecta otros `mat-select` del sistema (el fix es global)