### PR TITLE
feat(ui): implement dynamic company branding across the app

### DIFF
--- a/src/app/core/services/branding.service.ts
+++ b/src/app/core/services/branding.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { UserService } from './user.service';
 import { CompaniesService } from '../../features/companies/services/companies.service';
 
@@ -10,6 +10,11 @@ const FALLBACK_BG = '#f5f5f5';
 export class BrandingService {
   private readonly userService = inject(UserService);
   private readonly companiesService = inject(CompaniesService);
+
+  readonly companyName = signal<string | null>(null);
+  readonly logoUrl = signal<string | null>(null);
+  readonly primaryColor = signal<string>(DEFAULT_PRIMARY);
+  readonly secondaryColor = signal<string>(DEFAULT_SECONDARY);
 
   init(): void {
     this.applyFromCurrentCompany();
@@ -28,12 +33,12 @@ export class BrandingService {
 
     this.companiesService.findById(companyId).subscribe({
       next: (res) => {
-        const company = res;
         this.applyBranding(
-          company.colorPrimario || undefined,
-          company.colorSecundario || undefined,
-          company.logoUrl || undefined,
-          company.tema || undefined,
+          res.nombre || undefined,
+          res.colorPrimario || undefined,
+          res.colorSecundario || undefined,
+          res.logoUrl || undefined,
+          res.tema || undefined,
         );
       },
       error: () => this.applyDefaults(),
@@ -41,6 +46,7 @@ export class BrandingService {
   }
 
   private applyBranding(
+    name?: string,
     primary?: string,
     secondary?: string,
     logoUrl?: string,
@@ -51,15 +57,23 @@ export class BrandingService {
     const p = primary || DEFAULT_PRIMARY;
     const s = secondary || DEFAULT_SECONDARY;
 
+    this.companyName.set(name || null);
+    this.logoUrl.set(logoUrl || null);
+    this.primaryColor.set(p);
+    this.secondaryColor.set(s);
+
     root.style.setProperty('--brand-primary', p);
     root.style.setProperty('--brand-secondary', s);
     root.style.setProperty('--brand-primary-rgb', this.hexToRgb(p));
     root.style.setProperty('--brand-secondary-rgb', this.hexToRgb(s));
+    root.style.setProperty('--brand-contrast', this.isLightColor(p) ? '#000' : '#fff');
 
     if (logoUrl) {
       root.style.setProperty('--brand-logo-url', `url(${logoUrl})`);
+      root.style.setProperty('--brand-logo-image', logoUrl);
     } else {
       root.style.removeProperty('--brand-logo-url');
+      root.style.removeProperty('--brand-logo-image');
     }
 
     root.setAttribute('data-theme', theme === 'dark' ? 'dark' : 'light');
@@ -70,13 +84,29 @@ export class BrandingService {
 
   private applyDefaults(): void {
     const root = document.documentElement;
+    this.companyName.set(null);
+    this.logoUrl.set(null);
+    this.primaryColor.set(DEFAULT_PRIMARY);
+    this.secondaryColor.set(DEFAULT_SECONDARY);
+
     root.style.setProperty('--brand-primary', DEFAULT_PRIMARY);
     root.style.setProperty('--brand-secondary', DEFAULT_SECONDARY);
     root.style.setProperty('--brand-primary-rgb', this.hexToRgb(DEFAULT_PRIMARY));
     root.style.setProperty('--brand-secondary-rgb', this.hexToRgb(DEFAULT_SECONDARY));
+    root.style.setProperty('--brand-contrast', '#fff');
     root.style.removeProperty('--brand-logo-url');
+    root.style.removeProperty('--brand-logo-image');
     root.setAttribute('data-theme', 'light');
     root.style.setProperty('--app-bg', FALLBACK_BG);
+  }
+
+  private isLightColor(hex: string): boolean {
+    const cleaned = hex.replace('#', '');
+    const r = parseInt(cleaned.substring(0, 2), 16);
+    const g = parseInt(cleaned.substring(2, 4), 16);
+    const b = parseInt(cleaned.substring(4, 6), 16);
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return luminance > 0.5;
   }
 
   private hexToRgb(hex: string): string {

--- a/src/app/layout/main-layout/main-layout.component.ts
+++ b/src/app/layout/main-layout/main-layout.component.ts
@@ -32,7 +32,14 @@ import { NotificationPanelComponent } from '../../features/notificaciones/compon
           <mat-icon>menu</mat-icon>
         </button>
 
-        <span class="brand" routerLink="/">neoMotors</span>
+        <a class="brand" routerLink="/">
+          @if (brandingService.logoUrl(); as logo) {
+            <img [src]="logo" alt="Logo" class="brand-logo" />
+          } @else {
+            <mat-icon class="brand-icon">business</mat-icon>
+          }
+          <span class="brand-name">{{ brandingService.companyName() || userService.currentCompanyName() || 'Mi Empresa' }}</span>
+        </a>
 
         <span class="spacer"></span>
 
@@ -62,79 +69,79 @@ import { NotificationPanelComponent } from '../../features/notificaciones/compon
         <div class="sidenav">
           <nav class="nav-list">
             @if (userService.hasRole('SuperUsuario')) {
-              <a mat-menu-item routerLink="/companies" (click)="toggleMenu()">
+              <a routerLink="/companies" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact: true}" (click)="toggleMenu()">
                 <mat-icon>business</mat-icon>
                 Empresas
               </a>
             }
             @if (userService.currentCompanyId() && userService.hasAnyRole(['AdministradorEmpresa', 'SuperUsuario'])) {
-              <a mat-menu-item routerLink="/users" (click)="toggleMenu()">
+              <a routerLink="/users" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact: true}" (click)="toggleMenu()">
                 <mat-icon>group</mat-icon>
                 Usuarios
               </a>
             }
             @if (userService.currentCompanyId()) {
-              <a mat-menu-item routerLink="/dashboard" (click)="toggleMenu()">
+              <a routerLink="/dashboard" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact: true}" (click)="toggleMenu()">
                 <mat-icon>dashboard</mat-icon>
                 Dashboard
               </a>
-              <a mat-menu-item [routerLink]="['/branches']" [queryParams]="{ empresaId: userService.currentCompanyId() }" (click)="toggleMenu()">
+              <a [routerLink]="['/branches']" [queryParams]="{ empresaId: userService.currentCompanyId() }" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>store</mat-icon>
                 Sucursales
               </a>
-              <a mat-menu-item routerLink="/customers" (click)="toggleMenu()">
+              <a routerLink="/customers" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>people</mat-icon>
                 Clientes
               </a>
-              <a mat-menu-item routerLink="/vehicles" (click)="toggleMenu()">
+              <a routerLink="/vehicles" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>directions_car</mat-icon>
                 Vehículos
               </a>
-              <a mat-menu-item routerLink="/appointments" (click)="toggleMenu()">
+              <a routerLink="/appointments" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>calendar_today</mat-icon>
                 Citas
               </a>
-              <a mat-menu-item routerLink="/work-orders/reception" (click)="toggleMenu()">
+              <a routerLink="/work-orders/reception" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>assignment_returned</mat-icon>
                 Recepción
               </a>
-              <a mat-menu-item routerLink="/work-orders" (click)="toggleMenu()">
+              <a routerLink="/work-orders" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>build</mat-icon>
                 Órdenes
               </a>
-              <a mat-menu-item routerLink="/quotes" (click)="toggleMenu()">
+              <a routerLink="/quotes" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>request_quote</mat-icon>
                 Cotizaciones
               </a>
-              <a mat-menu-item routerLink="/suppliers" (click)="toggleMenu()">
+              <a routerLink="/suppliers" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>local_shipping</mat-icon>
                 Proveedores
               </a>
-              <a mat-menu-item routerLink="/purchase-orders" (click)="toggleMenu()">
+              <a routerLink="/purchase-orders" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>shopping_cart</mat-icon>
                 Compras
               </a>
-              <a mat-menu-item routerLink="/parts" (click)="toggleMenu()">
+              <a routerLink="/parts" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>handyman</mat-icon>
                 Refacciones
               </a>
-              <a mat-menu-item routerLink="/inventory" (click)="toggleMenu()">
+              <a routerLink="/inventory" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>inventory_2</mat-icon>
                 Inventario
               </a>
-              <a mat-menu-item routerLink="/cash-desk" (click)="toggleMenu()">
+              <a routerLink="/cash-desk" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>point_of_sale</mat-icon>
                 Caja
               </a>
-              <a mat-menu-item routerLink="/notifications" (click)="toggleMenu()">
+              <a routerLink="/notifications" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>notifications</mat-icon>
                 Notificaciones
               </a>
-              <a mat-menu-item routerLink="/audit-logs" (click)="toggleMenu()">
+              <a routerLink="/audit-logs" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>receipt_long</mat-icon>
                 Auditoría
               </a>
-              <a mat-menu-item routerLink="/fiscal/csd" (click)="toggleMenu()">
+              <a routerLink="/fiscal/csd" routerLinkActive="active-link" (click)="toggleMenu()">
                 <mat-icon>verified</mat-icon>
                 CSD
               </a>
@@ -182,14 +189,44 @@ import { NotificationPanelComponent } from '../../features/notificaciones/compon
       margin-left: 8px;
     }
 
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .brand-logo {
+      width: 28px;
+      height: 28px;
+      border-radius: 4px;
+      object-fit: contain;
+    }
+
+    .brand-icon {
+      font-size: 24px;
+      width: 24px;
+      height: 24px;
+    }
+
+    .brand-name {
+      font-weight: 600;
+      font-size: 16px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 240px;
+    }
+
     .sidenav {
       position: fixed;
       top: 64px;
       left: 0;
       width: 240px;
       height: calc(100vh - 64px);
-      background: var(--app-bg, #fff);
-      border-right: 1px solid #e0e0e0;
+      background: var(--brand-primary, #1976d2);
+      border-right: 1px solid rgba(0,0,0,0.12);
       z-index: 99;
       overflow-y: auto;
       padding: 8px 0;
@@ -206,12 +243,18 @@ import { NotificationPanelComponent } from '../../features/notificaciones/compon
       gap: 12px;
       padding: 12px 16px;
       text-decoration: none;
-      color: #333;
+      color: rgba(255,255,255,0.87);
       font-size: 14px;
+      transition: background 0.2s;
     }
 
     .nav-list a:hover {
-      background: #f5f5f5;
+      background: rgba(255,255,255,0.12);
+    }
+
+    .nav-list a.active-link {
+      background: var(--brand-secondary, #ff5722);
+      color: #fff;
     }
 
     .content {
@@ -228,7 +271,7 @@ import { NotificationPanelComponent } from '../../features/notificaciones/compon
 export class MainLayoutComponent implements OnInit {
   readonly userService = inject(UserService);
   private readonly router = inject(Router);
-  private readonly brandingService = inject(BrandingService);
+  protected readonly brandingService = inject(BrandingService);
   private menuOpenValue = false;
 
   menuOpen = () => this.menuOpenValue;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -20,6 +20,7 @@ html {
   --brand-primary-rgb: 25, 118, 210;
   --brand-secondary-rgb: 255, 87, 34;
   --app-bg: #f5f5f5;
+  --brand-contrast: #fff;
 }
 
 html, body { height: 100%; }
@@ -28,4 +29,37 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; background:
 [data-theme="dark"] {
   --app-bg: #121212;
   color-scheme: dark;
+}
+
+/* ── Branded table headers ── */
+.mat-mdc-header-row {
+  background: var(--brand-primary, #1976d2);
+}
+
+.mat-mdc-header-cell {
+  color: var(--brand-contrast, #fff) !important;
+  font-weight: 600;
+}
+
+/* ── Branded paginator ── */
+.mat-mdc-paginator {
+  --mat-paginator-enabled-icon-color: var(--brand-primary, #1976d2);
+  --mat-paginator-hover-icon-color: var(--brand-secondary, #ff5722);
+  --mat-paginator-container-background-color: transparent;
+}
+
+/* ── Branded chips (MAT M3) ── */
+.mat-mdc-chip {
+  --mdc-chip-elevated-container-color: rgba(var(--brand-primary-rgb, 25, 118, 210), 0.12);
+  --mdc-chip-label-text-color: var(--brand-primary, #1976d2);
+}
+
+/* ── Branded card headers / icon avatars ── */
+.mat-mdc-card .mat-mdc-card-header .mat-icon {
+  color: var(--brand-primary, #1976d2);
+}
+
+/* ── Dashboard bar-fill uses secondary brand color ── */
+.bar-fill {
+  background: var(--brand-secondary, #ff5722) !important;
 }


### PR DESCRIPTION
## Cambios realizados

### BrandingService (mejorado)
- Expone señales reactivas: `companyName`, `logoUrl`, `primaryColor`, `secondaryColor`
- Calcula automáticamente `--brand-contrast` (blanco/negro) según la luminancia del color primario para accesibilidad
- Almacena `--brand-logo-image` como URL directa (además de `--brand-logo-url` con `url()`)

### Toolbar (MainLayoutComponent)
- Reemplaza "neoMotors" por: **[Logo] Nombre de Empresa**
- Si no hay logo, muestra icono `business` por defecto
- Si no hay nombre comercial, usa el nombre registrado de la empresa
- Enlace al homepage (`/`) mediante `routerLink`

### Sidebar
- Fondo: `--brand-primary`
- Texto: blanco con opacidad 87%
- Hover: fondo semitransparente
- **Active link**: `--brand-secondary` como fondo (usando `routerLinkActive`)
- Se agregó `routerLinkActive="active-link"` a todos los ítems de navegación

### Tablas del sistema (styles.scss global)
- **Headers**: `background: var(--brand-primary)`, texto en contraste automático
- **Paginator**: colores de iconos según `--brand-primary` / `--brand-secondary`
- **Chips**: fondo tintado con `--brand-primary-rgb`, texto en color primario
- **Iconos de card**: color primario
- **Barras de dashboard**: color secundario

### Archivos modificados
| Archivo | Cambio |
|---------|--------|
| `branding.service.ts` | +señales reactivas, +cálculo de contraste, +logo image |
| `main-layout.component.ts` | toolbar con branding, sidebar coloreado, routerLinkActive |
| `styles.scss` | variables globales para tablas, chips, paginador, dashboard |

### No requiere cambios en
- Auth pages (login, register, recovery) — conservan "NeoMotors"
- Componentes individuales de lista/tabla — heredan de CSS variables globales
- Dashboard — usa `--brand-secondary` para barras