### PR TITLE
fix: repair corrupted merge in branding.service.ts

### DIFF
--- a/src/app/core/services/branding.service.ts
+++ b/src/app/core/services/branding.service.ts
@@ -71,11 +71,6 @@ export class BrandingService {
     this.primaryColor.set(p);
     this.secondaryColor.set(s);
 
-    this.companyName.set(name || null);
-    this.logoUrl.set(logoUrl || null);
-    this.primaryColor.set(p);
-    this.secondaryColor.set(s);
-
     root.style.setProperty('--brand-primary', p);
     root.style.setProperty('--brand-secondary', s);
     root.style.setProperty('--brand-primary-rgb', this.hexToRgb(p));
@@ -88,12 +83,6 @@ export class BrandingService {
     } else {
       root.style.removeProperty('--brand-logo-url');
       root.style.removeProperty('--brand-logo');
-    if (logoUrl) {
-      root.style.setProperty('--brand-logo-url', `url(${logoUrl})`);
-      root.style.setProperty('--brand-logo-image', logoUrl);
-    } else {
-      root.style.removeProperty('--brand-logo-url');
-      root.style.removeProperty('--brand-logo-image');
     }
 
     root.setAttribute('data-theme', theme === 'dark' ? 'dark' : 'light');
@@ -116,7 +105,6 @@ export class BrandingService {
     root.style.setProperty('--brand-contrast', '#fff');
     root.style.removeProperty('--brand-logo-url');
     root.style.removeProperty('--brand-logo');
-    root.style.removeProperty('--brand-logo-image');
     root.setAttribute('data-theme', 'light');
     root.style.setProperty('--app-bg', FALLBACK_BG);
   }


### PR DESCRIPTION
The develop branch had a corrupted merge in `branding.service.ts` causing `TS1128: Declaration or statement expected` at line 105. Root cause: duplicated signal assignments (`logoUrl` set twice) and a missing closing brace in the `else` block of the logo CSS variable logic, which caused `applyDefaults()` to be parsed inside `applyBranding()`. Removed 12 lines of duplicated code and closed the block correctly. Build verified.